### PR TITLE
Sicp kindle compat. & usability patches

### DIFF
--- a/lib/build_book.rb
+++ b/lib/build_book.rb
@@ -115,11 +115,18 @@ class BookBuilder
   end
 end
 
+
 if __FILE__ == $0
 
   Dir.chdir($LOCAL_ROOT)
  # Fix.do
-
+  if ARGV.include?("-h") or ARGV.include?("--help") or ARGV.include?("help")
+	  puts "Usage: build_book.rb [build] [toc] [opf]"
+	  puts "  build - Build the book"
+	  puts "  toc - Generate table of contents"
+	  puts "  opf - Generate OPF metadata file"
+	  exit
+  end
   bb = BookBuilder.new
   
   File.open($NCX_TOC, "w")    {|f| f.puts bb.ncx_toc} if ARGV.include?("toc")


### PR DESCRIPTION
Hi!

Here are a couple of patches which may or may not be useful. They're mostly updates for newer versions of things (ruby >1.9 and kindlegen 2.9) and usability changes (help texts, some failure analysis output).

This changeset also contains 2(!) patches for adding a hashbang to build_book.rb because I accidentally removed it again in f684b3a.

The patches are pretty *nix centric so if any of them pose a problem on Windows machines, I'm sorry.

Thanks for a nice little program!

Regards,
Anton
